### PR TITLE
Amazon uses space as scope separator

### DIFF
--- a/src/AmazonProvider.php
+++ b/src/AmazonProvider.php
@@ -14,6 +14,13 @@ class AmazonProvider extends AbstractProvider implements ProviderInterface
      * @var array
      */
     protected $scopes = ['profile'];
+    
+    /**
+     * The separating character for the requested scopes.
+     *
+     * @var string
+     */
+    protected $scopeSeparator = ' ';
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
This provider crashed when using more then one scope.